### PR TITLE
[COREPL-1086] fix: add gradle-opts inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ inputs:
     required: false
     default: ""
   gradle-opts:
-    description: "if it set, it overwrites recommend gradle opts (-Xmx128m -Dorg.gradle.jvmargs='-Xmx1g -XX:MaxPermSize=64m')
+    description: "if it set, it overwrites recommend gradle opts (-Xmx128m -Dorg.gradle.jvmargs='-Xmx1g -XX:MaxPermSize=64m')"
     required: false
     default: "-Xmx128m -Dorg.gradle.jvmargs='-Xmx1g -XX:MaxPermSize=64m'"
     

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,10 @@ inputs:
     description: "if it set, it overrides app version on the mortar.yaml file"
     required: false
     default: ""
+  gradle-opts:
+    description: "if it set, it overwrites recommend gradle opts (-Xmx128m -Dorg.gradle.jvmargs='-Xmx1g -XX:MaxPermSize=64m')
+    required: false
+    default: "-Xmx128m -Dorg.gradle.jvmargs='-Xmx1g -XX:MaxPermSize=64m'"
     
 outputs:
   app-version:
@@ -89,6 +93,7 @@ runs:
     - name: Mortar Deployment
       id: mortar-deploy
       env:
+        GRADLE_OPTS: ${{ inputs.gradle-opts }}
         DEBUG: "true"
       run: |
         mortar deploy -y \


### PR DESCRIPTION
## Proposed Changes
PROTO파일이 많아져서 Stubs 생성시 OOM 이 나는 문제를 방지하기 위해 메모리를 더 많이 할당하는 기본 gradle-opts 값을 제공.
